### PR TITLE
Fix Service, Ingress and cronJob base templates

### DIFF
--- a/charts/base/Chart.yaml
+++ b/charts/base/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Library Helm chart for base Kubernetes resources
 name: base
 type: library
-version: 0.1.0
+version: 0.1.1
 maintainers:
   - name: bonddim
 sources:

--- a/charts/base/templates/network/_ingress.tpl
+++ b/charts/base/templates/network/_ingress.tpl
@@ -45,8 +45,8 @@ Will generate default path "/" to "http" port if provided "paths" is empty
 */}}
 {{- define "base.ingress.paths" -}}
 {{- $service := include "base.names.fullname" .context -}}
-{{- $firstPort := $.context.Values.ports | first }}
-{{- $defaultPort := default $firstPort.containerPort $firstPort.port -}}
+{{- $firstPort := default list .context.Values.ports | first }}
+{{- $defaultPort := coalesce $firstPort.name $firstPort.port $firstPort.containerPort "http" -}}
 {{- range (ternary (list (dict "path" "/" "port" $defaultPort)) .paths (empty .paths)) }}
 - path: {{ .path }}
   {{- if eq "true" (include "common.ingress.supportsPathType" $.context) }}

--- a/charts/base/templates/network/_service.tpl
+++ b/charts/base/templates/network/_service.tpl
@@ -7,32 +7,31 @@ apiVersion: v1
 kind: Service
 metadata: {{- include "base.metadata" (dict "context" $ "values" .Values.service) | nindent 2 }}
 spec:
-{{- with .Values.service }}
-  {{- with .clusterIP }}
+  {{- with .Values.service.clusterIP }}
   clusterIP: {{ . }}
   {{- end }}
-  {{- with .externalIPs }}
+  {{- with .Values.service.externalIPs }}
   externalIPs: {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .externalName }}
+  {{- with .Values.service.externalName }}
   externalName: {{ . }}
   {{- end }}
-  {{- with .externalTrafficPolicy }}
+  {{- with .Values.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ . }}
   {{- end }}
-  {{- with .healthCheckNodePort }}
+  {{- with .Values.service.healthCheckNodePort }}
   healthCheckNodePort: {{ . }}
   {{- end }}
-  {{- with .loadBalancerIP }}
+  {{- with .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ . }}
   {{- end }}
-  {{- with .loadBalancerSourceRanges }}
+  {{- with .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{- toYaml . | nindent 4 }}
   {{- end }}
   ports:
     {{- /* Use service.ports only if defined */ -}}
-    {{- if .ports }}
-    {{- range .ports }}
+    {{- if .Values.service.ports }}
+    {{- range .Values.service.ports }}
     - port: {{ .port | int }}
       targetPort: {{ default .port .targetPort | int }}
       {{- with .appProtocol }}
@@ -67,21 +66,20 @@ spec:
       {{- end }}
     {{- end }}
     {{- end }}
-  {{- with .publishNotReadyAddresses }}
+  {{- with .Values.service.publishNotReadyAddresses }}
   publishNotReadyAddresses: {{ . }}
   {{- end }}
   selector: {{- include "base.labels.matchLabels" (dict "context" $ "customLabels" $.Values.podLabels) | nindent 4 }}
-  {{- with .sessionAffinity }}
+  {{- with .Values.service.sessionAffinity }}
   sessionAffinity: {{ . }}
   {{- end }}
-  {{- with .sessionAffinityConfig }}
+  {{- with .Values.service.sessionAffinityConfig }}
   sessionAffinityConfig: {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .topologyKeys }}
+  {{- with .Values.service.topologyKeys }}
   topologyKeys: {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .type }}
+  {{- with .Values.service.type }}
   type: {{ . }}
   {{- end }}
-{{- end -}}
 {{- end -}}

--- a/charts/base/templates/workloads/_cronjob.tpl
+++ b/charts/base/templates/workloads/_cronjob.tpl
@@ -6,8 +6,8 @@
 apiVersion: {{ include "common.capabilities.cronjob.apiVersion" . }}
 kind: CronJob
 metadata: {{- include "base.metadata" (dict "context" . "values" .Values.cronjob) | nindent 2 }}
-{{- with .Values.cronjob }}
 spec:
+  {{- with .Values.cronjob }}
   {{- with .concurrencyPolicy }}
   concurrencyPolicy: {{ . }}
   {{- end }}
@@ -27,7 +27,7 @@ spec:
   {{- with .timeZone }}
   timeZone: {{ . }}
   {{- end }}
+  {{- end }}
   jobTemplate:
-    spec: {{- include "base.job.spec" (dict "context" $ "jobValues" .job) | nindent 6 }}
-{{- end -}}
+    spec: {{- include "base.job.spec" (dict "context" $ "jobValues" .Values.cronjob.job) | nindent 6 }}
 {{- end -}}


### PR DESCRIPTION
- Render base Service template without any values
- Render almost valid CronJob without values (schedule is required)
- Render default port for ingress from container's first port name, port, containerPort properties
